### PR TITLE
Implement version flag and add unit test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+import sys
+import unittest
+from unittest.mock import patch
+
+
+class TestVersion(unittest.TestCase):
+    @patch("builtins.print")
+    def test_version_argument(self, mock_print):
+        test_args = ["uswfc", "--version"]
+        with patch.object(sys, 'argv', test_args):
+            from uswfc.cli import main
+            with patch("uswfc.__version__", "1.0.0"):
+                main()
+                mock_print.assert_called_with("uswfc 1.0.0")

--- a/uswfc/cli.py
+++ b/uswfc/cli.py
@@ -5,3 +5,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Weather Forecast API Utility")    
     parser.add_argument("-v", "--version", action="store_true", help="show weatherf version")
     arguments = parser.parse_args()
+
+    if arguments.version:
+        from . import __version__
+        print(f"uswfc {__version__}")


### PR DESCRIPTION
1. Implement version flag:
    - Adds functionality to display the version when the --version flag is passed.
    - The version is retrieved from the __version__ constant in __init__.py.
2. Add version flag unit test:
    - Ensures that when the --version argument is provided, the correct version number is printed.